### PR TITLE
feat(DatePicker): add original datePicker props

### DIFF
--- a/src/_components/DateComponents/DatePickerComponent.tsx
+++ b/src/_components/DateComponents/DatePickerComponent.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useMemo } from 'react'
-import { Calendar } from 'react-date-range'
+import { Calendar, CalendarProps } from 'react-date-range'
 import { formatDate } from '../../helpers/utils'
 import DateComponentWrapper from './DateComponentWrapper'
 import { CustomComponentImplementation } from '../../types'
@@ -8,6 +8,7 @@ interface DatePickerComponentProps extends CustomComponentImplementation<Date> {
   title: string
   onChange?: ( date: Date ) => void
   dateDisplayFormat?: string
+  datePickerProps?: CalendarProps
 }
 
 const DatePickerComponent: FC<DatePickerComponentProps> = (
@@ -18,11 +19,16 @@ const DatePickerComponent: FC<DatePickerComponentProps> = (
     defaultValue,
     onUpdateValue,
     value,
+    datePickerProps: {
+      onChange: datePickerOnChange,
+      ...datePickerProps
+    } = {},
     ...props
   } ) => {
   const updateDate = ( date: Date ) => {
     onChange && onChange( date )
     onUpdateValue && onUpdateValue( date )
+    datePickerOnChange?.(date)
   }
 
   const date = useMemo( () => {
@@ -40,7 +46,10 @@ const DatePickerComponent: FC<DatePickerComponentProps> = (
       <Calendar
         editableDateInputs={ true }
         date={ value }
-        onChange={ updateDate } { ...{ dateDisplayFormat } } />
+        onChange={ updateDate }
+        { ...{ dateDisplayFormat } }
+        {...datePickerProps}
+      />
     </DateComponentWrapper>
   )
 }

--- a/src/_components/DateComponents/DateRangePickerComponent.tsx
+++ b/src/_components/DateComponents/DateRangePickerComponent.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback, useMemo } from 'react'
-import { DateRange, Range, RangeKeyDict } from 'react-date-range'
+import { DateRange, DateRangeProps, Range, RangeKeyDict } from 'react-date-range'
 import { formatDate } from '../../helpers/utils'
 import DateComponentWrapper from './DateComponentWrapper'
 import { CustomComponentImplementation } from '../../types'
@@ -11,6 +11,7 @@ interface DatePickerComponentProps extends CustomComponentImplementation<[ Date,
   onChange?: ( dates: DatePickerRangeDate ) => void
   dateDisplayFormat?: string
   isDisabled?: boolean
+  dateRangePickerProps?: DateRangeProps
 }
 
 const DateRangePickerComponent: FC<DatePickerComponentProps> = ( {
@@ -20,11 +21,17 @@ const DateRangePickerComponent: FC<DatePickerComponentProps> = ( {
                                                                    defaultValue,
                                                                    value,
                                                                    onUpdateValue,
+                                                                   dateRangePickerProps: {
+                                                                     onChange: dateRangePickerOnChange,
+                                                                     ...dateRangePickerProps
+                                                                   } = {},
                                                                    ...props
                                                                  } ) => {
   const updateRange = ( range: Range[] ) => {
-    onChange && onChange( [ range[0].startDate!, range[0].endDate! ] )
-    onUpdateValue && onUpdateValue( [ range[0].startDate!, range[0].endDate! ] )
+    const newRange = [ range[0].startDate!, range[0].endDate! ];
+    onChange && onChange( newRange )
+    onUpdateValue && onUpdateValue( newRange )
+    dateRangePickerOnChange?.(newRange)
   }
 
   const date = useCallback( ( pos: number ) => {
@@ -71,6 +78,7 @@ const DateRangePickerComponent: FC<DatePickerComponentProps> = ( {
         ] }
         rangeColors={ [ 'primary', 'primary' ] }
         { ...{ dateDisplayFormat } }
+        { ...dateRangePickerProps }
       />
     </DateComponentWrapper>
   )


### PR DESCRIPTION
Add opportunity to pass original DatePicker props to component. It can help to customise behaviour.
Example: make weekends (sat and sun) cannot be selected. 